### PR TITLE
fix: Extract key_id that works with gpg 2.4.4

### DIFF
--- a/gen_new_gpg_key.sh
+++ b/gen_new_gpg_key.sh
@@ -17,8 +17,8 @@ out=$(gpg --full-gen-key --batch <(echo "Key-Type: 1"; \
                                    echo "Passphrase: ${PW}"; ) 2>&1)
 #                                  echo "%no-protection"; ) 2>&1)
 #
-key_id="$(echo "$out"|sed -En 's|.+key ([[:xdigit:]]+) marked.+|\1|p')"
 rev_cert="$(echo "$out"|sed -En "s|.+revocation certificate stored as '([^']+)'.*|\1|p")"
+key_id="$(echo $rev_cert | sed -En "s|.*([0-9A-F]{16})\.rev|\1|p")"
 finger="$(gpg --fingerprint ${key_id}|sed -n '2{s|^\s*||p}')"
 #
 if [ -n "$key_id" -a -n "$rev_cert" ]; then


### PR DESCRIPTION
Fixes #30 

This should work just fine with older versions of gpg as the key ID was always going to be contained in the `$rev_cert` filename.